### PR TITLE
[Obstacle Avoidance] fix path to trajectories in env demo

### DIFF
--- a/movement_primitive_diffusion/workspaces/obstacle_avoidance/obstacle_avoidance_env.py
+++ b/movement_primitive_diffusion/workspaces/obstacle_avoidance/obstacle_avoidance_env.py
@@ -776,7 +776,7 @@ if __name__ == "__main__":
 
     git_repo = git.Repo(".", search_parent_directories=True)
     git_root = git_repo.git.rev_parse("--show-toplevel")
-    trajectories_root = Path(git_root) / "data" / f"obstacle_avoidance_trajectories_{dataset_hz}_hz"
+    trajectories_root = Path(git_root) / "data" / f"obstacle_avoidance"
 
     dataset = TrajectoryDataset(
         trajectory_dirs=[path for path in trajectories_root.iterdir() if path.is_dir()],


### PR DESCRIPTION
Fixed the path to the demo trajectories for the obstacle avoidance environment when testing the env via:
`python ./movement_primitive_diffusion/workspaces/obstacle_avoidance/obstacle_avoidance_env.py`